### PR TITLE
Add parameter to control if sending 'now' parameter of LogDNA REST API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This configuration is based on an [asynchronous wrapper](https://logback.qos.ch/
 * Set up comma-separated tags if you want to.
 * Set up comma-separated MDC keys to index (from the MDC thread local binding).
 * Set up one type for each MDC key.
-* If you use time drift (<useTimeDrift>true</useTimeDrift>), the appender will send 'now' paramter and LogDNA uses this for time drift calculation. In this case, the time stamp shown on your LogDNA dashboard will not as same as the time stamp you sent because of time drift treatment. If you want to see the same time stamp as you post by your appender, specify false(<useTimeDrift>false</useTimeDrift>). Default value is true. For more information, consult the 'now' parameter of LogDNA REST API (https://docs.logdna.com/reference).
+* If you use time drift (&lt;useTimeDrift&gt;true&lt;/useTimeDrift&gt;), the appender will send 'now' paramter and LogDNA uses this for time drift calculation. In this case, the time stamp shown on your LogDNA dashboard will not as same as the time stamp you sent because of time drift treatment. If you want to see the same time stamp as you post by your appender, specify false(&lt;useTimeDrift&gt;false&lt;/useTimeDrift&gt;). Default value is true. For more information, consult the 'now' parameter of LogDNA REST API (https://docs.logdna.com/reference).
 
 Possible types are string, boolean, int and long. The last two result in an indexed number in your LogDNA console, which is rather interesting, as it will allow you some functions inside your graphs (sum, average, etc...).
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Copy the following two LogDna appenders to your `classpath:/logback.xml` file.
             <mdcFields>field1,field2</mdcFields>
             <mdcTypes>string,int</mdcTypes>
             <tags>dev</tags>
+            <useTimeDrift>true</useTimeDrift>
         </appender>
         
         <appender name="LogDna" class="ch.qos.logback.classic.AsyncAppender">
@@ -62,6 +63,7 @@ This configuration is based on an [asynchronous wrapper](https://logback.qos.ch/
 * Set up comma-separated tags if you want to.
 * Set up comma-separated MDC keys to index (from the MDC thread local binding).
 * Set up one type for each MDC key.
+* If you use time drift (<useTimeDrift>true</useTimeDrift>), the appender will send 'now' paramter and LogDNA uses this for time drift calculation. In this case, the time stamp shown on your LogDNA dashboard will not as same as the time stamp you sent because of time drift treatment. If you want to see the same time stamp as you post by your appender, specify false(<useTimeDrift>false</useTimeDrift>). Default value is true. For more information, consult the 'now' parameter of LogDNA REST API (https://docs.logdna.com/reference).
 
 Possible types are string, boolean, int and long. The last two result in an indexed number in your LogDNA console, which is rather interesting, as it will allow you some functions inside your graphs (sum, average, etc...).
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
   <tag>HEAD</tag>
  </scm>
 
+ <properties>
+   <gpg.skip>false</gpg.skip>
+ </properties>
+
  <build>
   <plugins>
    <plugin>

--- a/src/test/java/net/zileo/logback/logdna/LogDnaAppenderTest.java
+++ b/src/test/java/net/zileo/logback/logdna/LogDnaAppenderTest.java
@@ -1,10 +1,5 @@
 package net.zileo.logback.logdna;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Collection;
 import java.util.Map;
 
@@ -16,6 +11,8 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
+
+import static org.junit.Assert.*;
 
 public class LogDnaAppenderTest {
 
@@ -40,6 +37,11 @@ public class LogDnaAppenderTest {
         appender.setAppName("LogDnaTest");
         appender.setMdcFields("field1,field3,field4,field5");
         appender.setMdcTypes("string,int,boolean,long");
+        assertTrue(appender.useTimeDrift);
+        appender.setUseTimeDrift("false");
+        assertFalse(appender.useTimeDrift);
+        appender.setUseTimeDrift("true");
+        assertTrue(appender.useTimeDrift);
 
         // Build up future-JSON data
         Map<String, Object> postData = appender.buildPostData(ev);


### PR DESCRIPTION
In LogDNA, 'now' parameter is used for time stamp drift calculation. Since this appender send 'timestamp', not to send 'now' parameter is sometimes convenient because if you send 'now' parameter, the log time stamp shown on the LogDNA dash board will differ from the 'timestamp' you send.